### PR TITLE
Update app.js

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -46,14 +46,13 @@ window.addEventListener("DOMContentLoaded", () => {
 		THUMBNAIL_IMAGES_PATHS[0]
 	);
 
-	if (window.innerWidth < 1440) {
-		const mobileCarousel = new MobileCarousel(
-			LARGE_IMAGE_SELECTOR,
-			PREVIOUS_BUTTON_SELECTOR,
-			NEXT_BUTTON_SELECTOR,
-			LARGE_IMAGES_PATHS
-		);
-	}
+	const mobileCarousel = new MobileCarousel(
+		LARGE_IMAGE_SELECTOR,
+		PREVIOUS_BUTTON_SELECTOR,
+		NEXT_BUTTON_SELECTOR,
+		LARGE_IMAGES_PATHS
+	);
+
 
 	document
 		.querySelector(LARGE_IMAGE_SELECTOR)


### PR DESCRIPTION
Stop instantiating `mobileCarousel` only when the screen width is above 1440px.

The "optimization" caused bugs.

Since the user might decide to resize the window at any moment, it's better to have the functionality available and hide the controls (next/previous buttons) with CSS.