### PR TITLE
Update DesktopCarousel.js

### DIFF
--- a/src/js/DesktopCarousel.js
+++ b/src/js/DesktopCarousel.js
@@ -97,7 +97,7 @@ class DesktopCarousel {
 		// If the first image in the list is displayed, we replace it with the last image.
 		if (indexOfImage === 0) {
 			this.replaceLargeImagePath(
-				`/src/images/image-product-${this.largeImagesPaths.length}.jpg`
+				`${this.largeImagesPaths[this.largeImagesPaths.length - 1]}`
 			);
 		} else {
 			const newIndex = indexOfImage - 1;


### PR DESCRIPTION
Fix `displayPreviousImage()` to use a fully dynamic path to point to the right resource in production.

Solved the same issue for this class' `displayPreviousImage()` that occurred in `MobileCarousel.displayPreviousImage()` see #13 .