### PR TITLE
Fix images paths

### DIFF
--- a/src/js/MobileCarousel.js
+++ b/src/js/MobileCarousel.js
@@ -54,7 +54,7 @@ class MobileCarousel {
 		// If the first image in the list is displayed, we replace it with the last image.
 		if (indexOfImage === 0) {
 			this.replaceLargeImagePath(
-				`/src/images/image-product-${this.largeImagesPaths.length}.jpg`
+				`${this.largeImagesPaths[this.largeImagesPaths.length - 1]}`
 			);
 		} else {
 			const newIndex = indexOfImage - 1;


### PR DESCRIPTION
Fix displayPreviousImage() to use a fully dynamic path to point to the right resource in production.

Solved the same issue for this class' displayPreviousImage() that occurred in MobileCarousel.displayPreviousImage() see https://github.com/AngeliqueDF/e-commerce-product-page/issues/13 .